### PR TITLE
Choose word to guess

### DIFF
--- a/PlayerOne/index.html
+++ b/PlayerOne/index.html
@@ -17,7 +17,8 @@
         <div class="container-fluid text-center">
             <h1 class=title> Draw the following word</h1>
             <h1 id='randomWord' class=word></h1>
-            <button class="get-Word">Get New Word</button>
+            <button id="get-new-word" class="get-Word">Get New Word</button>
+            <button id="choose-word">Choose this word to draw</button>
         </div>
         <div>
             <canvas id="canvas"></canvas>
@@ -37,6 +38,7 @@
         <script src="./index.js"></script>
         <script src="../Canvas/canvas.js"></script>
         <script src="playerTwoGuesses.js"></script>
+        <script src="submitWordToGuess.js"></script>
         <!-- <script src="main-js"></script> -->
     </body>
 

--- a/PlayerOne/index.js
+++ b/PlayerOne/index.js
@@ -33,5 +33,30 @@ $(document).ready(function() {
       randomWord = wordsArray[0][Math.floor(Math.random() * 31)];
       $("#randomWord").text(randomWord);
   });
+
+  $('#choose-word').on("click", function(event) { // send the chosen word to player two's page for validation
+    console.log('choosing this word');
+    chosenWord = $("#randomWord").text();
+    guessConnection.send(INCOMING_SUBMITTED_WORD + chosenWord);
+
+    //once they choose the word, they shouldn't be able to choose a new word, or get a new word
+    document.getElementById("choose-word").style.display = "none";
+    document.getElementById("get-new-word").style.display = "none";
+  })
 })
+
+//  web socket connection
+const url = "wss://i788c.sse.codesandbox.io/";
+const guessConnection = new WebSocket(url + "chosen-word"); // create a new websocket connection to port 8080 - connect to specific endpoint 'submit-word'
+const INCOMING_SUBMITTED_WORD = "INCOMING SUBMITTED WORD: "; // put this at the beginning of the message
+
+guessConnection.onopen = () => { // when the connection to port 8080 is made
+  guessConnection.send("hello from player one's word submission connection");
+}
+
+guessConnection.onerror = err => { // if the connection has an error
+  console.log(`Websocket error ${err}`)
+}
+
+
 

--- a/PlayerOne/playerTwoGuesses.js
+++ b/PlayerOne/playerTwoGuesses.js
@@ -11,19 +11,19 @@ const displayPreviousGuesses = (lastGuess) => {
 
 //  web socket connection
 const url = "wss://i788c.sse.codesandbox.io/";
-const connection = new WebSocket(url); // create a new websocket connection to port 8080
+const guessConnection = new WebSocket(url + "guess"); // create a new websocket connection to port 8080
 const INCOMING_GUESS = "INCOMING GUESS: "; // put this at the beginning of the message
 
-connection.onopen = () => { // when the connection to port 8080 is made
+guessConnection.onopen = () => { // when the connection to port 8080 is made
     console.log("player one connected"); // testing message
-    connection.send("hello from player one");
+    guessConnection.send("hello from player one");
 }
 
-connection.onerror = err => { // if the connection has an error
+guessConnection.onerror = err => { // if the connection has an error
     console.log(`Websocket error ${err}`)
 }
 
-connection.onmessage = e => { // if this connection recieves a message from the server
+guessConnection.onmessage = e => { // if this connection recieves a message from the server
     console.log(e.data)
     displayPreviousGuesses(String(e.data).replace(INCOMING_GUESS, ""))
 }

--- a/PlayerTwo/playerGuessInput.js
+++ b/PlayerTwo/playerGuessInput.js
@@ -1,4 +1,4 @@
-const answer = "Cat";
+var answer = "Cat";
 var lives = 5;
 
 
@@ -52,7 +52,7 @@ const displayPreviousGuesses = (lastGuess) => {
 
 
 const sendGuess = (guess) => {
-    connection.send(`${INCOMING_GUESS}${guess}`)
+    guessConnection.send(`${INCOMING_GUESS}${guess}`)
 }
 
 
@@ -61,24 +61,35 @@ const minusLivesRemaining = () => {
 }
 
 
-//  web socket connection
+//  web socket connections
+
+// for sending guesses to the server
 const url = "wss://i788c.sse.codesandbox.io/";
-const connection = new WebSocket(url); // create a new websocket connection to port 8080
+const guessConnection = new WebSocket(url + "guess"); // create a new websocket connection to port 8080 --> send to endpoint "guess"
 const INCOMING_GUESS = "INCOMING GUESS: "; // put this at the beginning of the message
 
-connection.onopen = () => { // when the connection to port 8080 is made
+guessConnection.onopen = () => { // when the connection to port 8080 is made
     console.log("player two connected"); // testing message
-    connection.send("hello");
+    guessConnection.send("hello");
 }
 
-connection.onerror = err => { // if the connection has an error
-    console.log(`Websocket error ${err}`);
+guessConnection.onerror = err => { // if the connection has an error
+    console.log(`Websocket error ${err}`)
 }
 
-connection.onmessage = e => { // if this connection recieves a message from the server
-    console.log(e.data)
-    displayPreviousGuesses(String(e.data).replace(INCOMING_GUESS, ""));
+
+// collect the chosen word from player one
+const chosenWordConnection = new WebSocket(url + "chosen-word");
+
+chosenWordConnection.onopen = () => {
+    chosenWordConnection.send("player two is ready to receive the chosen word");
 }
+
+chosenWordConnection.onmessage = (e) => {
+    answer = e.data;
+    console.log('answer is now: ' + answer);
+}
+
 
 
 

--- a/PlayerTwo/playerGuessInput.js
+++ b/PlayerTwo/playerGuessInput.js
@@ -21,15 +21,21 @@ const isCorrectGuess = () => {
 
         document.getElementById("input-result").innerHTML = "correct!";
 
+        displayPreviousGuesses(userGuess)
+
         sendGuess(userGuess);
+
     } else {
         document.getElementById("input-result").innerHTML = "incorrect";
         lives -= 1;
 
-        displayLivesRemaining();
+        minusLivesRemaining();
+
+        displayPreviousGuesses(userGuess);
 
         // THIS SENDS THE GUESS TO THE SERVER
         sendGuess(userGuess);
+
     }
 }
 
@@ -50,7 +56,7 @@ const sendGuess = (guess) => {
 }
 
 
-const displayLivesRemaining = () => {
+const minusLivesRemaining = () => {
     document.getElementById('lives').innerHTML = "lives: " + lives;
 }
 
@@ -66,12 +72,12 @@ connection.onopen = () => { // when the connection to port 8080 is made
 }
 
 connection.onerror = err => { // if the connection has an error
-    console.log(`Websocket error ${err}`)
+    console.log(`Websocket error ${err}`);
 }
 
 connection.onmessage = e => { // if this connection recieves a message from the server
     console.log(e.data)
-    displayPreviousGuesses(String(e.data).replace(INCOMING_GUESS, ""))
+    displayPreviousGuesses(String(e.data).replace(INCOMING_GUESS, ""));
 }
 
 


### PR DESCRIPTION
Once player one decides on a word to draw, a button has been added so that they can `choose the word`, which sends the word via WebSocket to player 2's client. Player 2's page needs access to the chosen word so that it can check if player two's guesses are correct. 

When player one presses `choose word`, both the `choose word` and `Get New Word` buttons are hidden from the user so they cannot choose a new word. I think this will also be useful if we want to start a timer feature in the future.

I've also started using the app's WebSocket routes - so that we do not get confused over the different WebSocket connections as we add more, all connections send messages to a dedicated endpoint (e.g. `/guess` or `/draw`). I've changed the server so that it expects to receive these endpoints, so you will have to check out this branch to get the clients to connect properly with the server.